### PR TITLE
Update facebookresearch/WSL-Images torchhub repository

### DIFF
--- a/merged_depth/nets/MiDaS/midas/blocks.py
+++ b/merged_depth/nets/MiDaS/midas/blocks.py
@@ -82,7 +82,7 @@ def _make_resnet_backbone(resnet):
 
 
 def _make_pretrained_resnext101_wsl(use_pretrained):
-    resnet = torch.hub.load("facebookresearch/WSL-Images", "resnext101_32x8d_wsl")
+    resnet = torch.hub.load("facebookresearch/WSL-Images:main", "resnext101_32x8d_wsl")
     return _make_resnet_backbone(resnet)
 
 


### PR DESCRIPTION
This change resolves a 404 error from facebookresearch WSL-Images 
```
Downloading: "https://github.com/facebookresearch/WSL-Images/archive/master.zip" to /home/mike/.cache/torch/hub/master.zip
Traceback (most recent call last):
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/mike/Workspaces/enli/merged_depth/merged_depth/infer_single.py", line 36, in <module>
    main(args.path)
  File "/home/mike/Workspaces/enli/merged_depth/merged_depth/infer_single.py", line 13, in main
    engine = InferenceEngine()
  File "/home/mike/Workspaces/enli/merged_depth/merged_depth/infer.py", line 83, in __init__
    self.midas_model = MidasNet(self.midas_model_path, non_negative=True)
  File "/home/mike/Workspaces/enli/merged_depth/merged_depth/nets/MiDaS/midas/midas_net.py", line 30, in __init__
    self.pretrained, self.scratch = _make_encoder(backbone="resnext101_wsl", features=features, use_pretrained=use_pretrained)
  File "/home/mike/Workspaces/enli/merged_depth/merged_depth/nets/MiDaS/midas/blocks.py", line 7, in _make_encoder
    pretrained = _make_pretrained_resnext101_wsl(use_pretrained)
  File "/home/mike/Workspaces/enli/merged_depth/merged_depth/nets/MiDaS/midas/blocks.py", line 85, in _make_pretrained_resnext101_wsl
    resnet = torch.hub.load("facebookresearch/WSL-Images", "resnext101_32x8d_wsl")
  File "/home/mike/.pyenv/versions/merged_depth/lib/python3.8/site-packages/torch/hub.py", line 337, in load
    repo_or_dir = _get_cache_or_reload(repo_or_dir, force_reload, verbose)
  File "/home/mike/.pyenv/versions/merged_depth/lib/python3.8/site-packages/torch/hub.py", line 144, in _get_cache_or_reload
    download_url_to_file(url, cached_file, progress=False)
  File "/home/mike/.pyenv/versions/merged_depth/lib/python3.8/site-packages/torch/hub.py", line 394, in download_url_to_file
    u = urlopen(req)
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/urllib/request.py", line 640, in http_response
    response = self.parent.error(
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/urllib/request.py", line 563, in error
    result = self._call_chain(*args)
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/urllib/request.py", line 502, in _call_chain
    result = func(*args)
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/urllib/request.py", line 755, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/urllib/request.py", line 640, in http_response
    response = self.parent.error(
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/urllib/request.py", line 502, in _call_chain
    result = func(*args)
  File "/home/mike/.pyenv/versions/3.8.11/lib/python3.8/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
```